### PR TITLE
Fixed bug on EquipmentSlotUI

### DIFF
--- a/Major Production/Assets/_Scripts/UI/Drag and Drop/EquipmentSlotUI.cs
+++ b/Major Production/Assets/_Scripts/UI/Drag and Drop/EquipmentSlotUI.cs
@@ -47,7 +47,7 @@ namespace RPG.UI {
 			if (draggedItem != null && draggedItem.itemBox != this)
 			{
 				// Check type of dragged item
-				Equipment theirItem = (Equipment)draggedItem.itemBox.ContainedItem;
+				Equipment theirItem = draggedItem.itemBox.ContainedItem as Equipment;
 				if(theirItem == null)
 				{
 					return false;


### PR DESCRIPTION
Trying to move consumable into equipmentslot previously threw exception, leaving draggable there. This was fixed