### PR TITLE
Continue button continues fight without changing characters

### DIFF
--- a/Major Production/Assets/_Scripts/RPG system/StateManager.cs
+++ b/Major Production/Assets/_Scripts/RPG system/StateManager.cs
@@ -257,9 +257,11 @@ namespace RPGsys {
 						}
 
 						//shows the current players buttons, will only move on if player selects new character
-						while(characters[i].ActivePlayer == true) {
-							yield return null;
-						}
+						System.Func<bool> waiting = () => { return characters[i].ActivePlayer == true && PlayerTurnOver == false; };
+						yield return new WaitWhile(waiting);
+						//while(characters[i].ActivePlayer == true) {
+						//	yield return null;
+						//}
 
 						//sets them out of idle state, hides their power buttons
 						MoveSetCheck(i);


### PR DESCRIPTION
Clicking continue button ends turn without having to change characters. This also means battles don't lock if only one character in player team